### PR TITLE
Feature/prepare json yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-## :mega: Repository No Longer Being Maintained :mega:
+## :mega: Repository No Longer Being Maintained by DCAN-Labs :mega:
 
-**We have adopted a new process for storing and sharing ABCD data and will therefore no longer be maintaining this repository!**
+**DCAN-Labs has adopted a new process for storing and sharing ABCD data and will therefore no longer be maintaining this repository!**
 
 
 # Welcome to the DCAN Labs NDA BIDS Upload Repository

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **DCAN-Labs has adopted a new process for storing and sharing ABCD data and will therefore no longer be maintaining this repository!**
 
 
-# Welcome to the DCAN Labs NDA BIDS Upload Repository
+# Welcome to the NDA BIDS Upload Repository
 
 This repository is for taking data as BIDS and uploading it to an NDA collection.
 

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -11,20 +11,23 @@ from pathlib import Path
 
 class BIDStoNDAConfigGenerator:
     def __init__(self):
-        # TODO:
-        # add below in the command line args
-        # -d: destination folder where the yaml and json files need to be saved
-        # -s: source directory where the BIDS dataset is located
+        # Set BIDS configuration
         bids.config.set_option('extension_initial_dot', True)
-        parser = argparse.ArgumentParser(description='Process a dataset path.')
-        parser.add_argument('dataset_path', type=str, help='The path to the dataset directory')
-        args = parser.parse_args()
-        self.path = args.dataset_path
 
-        self.layout = BIDSLayout(self.path, derivatives=False)
+        # Parse command-line arguments
+        parser = argparse.ArgumentParser(description='Generate YAML and JSON files for a BIDS dataset.')
+        parser.add_argument('-s', '--source', type=str, required=True, help='Path to the BIDS dataset directory')
+        parser.add_argument('-d', '--destination', type=str, required=True, help='Path to save the generated YAML and JSON files')
+        args = parser.parse_args()
+        self.source_path = args.source
+        self.destination_path = Path(args.destination)
+
+        # Initialize BIDS layout
+        self.layout = BIDSLayout(self.source_path, derivatives=True)
+
+        # Define constants
         self.A = 'image03'
         self.pattern = r'^(?P<A>[^_]+)_(?P<X>[^.]+)\.(?P<Y>[^.]+)\.(?P<Z>[^.]+)\..+$'
-
         self.scan_type = {
             'anat': {
                 'mprage': 'MR structural (MPRAGE)',
@@ -53,55 +56,47 @@ class BIDStoNDAConfigGenerator:
             'dwi': 'MRI',
             'fmap': 'MRI'
         }
+        
+        # Set output directories
+        self.json_dir = self.destination_path / 'prepared_jsons'
+        self.yaml_dir = self.destination_path / 'prepared_yamls'
+        self.json_dir.mkdir(parents=True, exist_ok=True)
+        self.yaml_dir.mkdir(parents=True, exist_ok=True)
 
     def extract_file_name_components(self, file_name):
         match = re.match(self.pattern, file_name)
-        if match:
-            A = match.group('A')
-            X = match.group('X')
-            Y = match.group('Y')
-            Z = match.group('Z')
-            return A, X, Y, Z
-        else:
-            return None
+        return match.groups() if match else (None, None, None, None)
 
-    def prepare_json_contents(self, file_name):
+
+    def prepare_json_contents(self, file_name, files):
         json_contents = {}
-        _, X, Y, _ = self.extract_file_name_components(file_name)
-        files = self.layout.get(
-            scope=X if X != 'inputs' else 'raw', datatype=Y, return_type='file')
+        _, X, _, _ = self.extract_file_name_components(file_name)
+
+        sub_path_prefix = {
+            'derivatives': 'derivatives',
+            'inputs': 'sub-'
+        }
+        
         for file_path in files:
-            sub_index = file_path.find('derivatives')
-            
-            if sub_index != -1:
-                sub_path = file_path[sub_index:]
-                entities = self.layout.parse_file_entities(sub_path)
-                subject = entities.get('subject')
-                session = entities.get('session')
-                if subject:
-                    sub_path = sub_path.replace(subject, '{SUBJECT}')
-                if session:
-                    sub_path = sub_path.replace(session, '{SESSION}')
-                sub_path = re.sub(r'-\d', '-{#}', sub_path)
-                json_contents[sub_path] = sub_path
-            else:
-                sub_index = file_path.find('sub-')
-        finalPath = '/'.join(self.path.split('/')[:-2]) + '/prepared_jsons'
-        Path(finalPath).mkdir(parents=True, exist_ok=True)
-        with open(f'{finalPath}/'+file_name, 'w') as f:
-            json.dump(json_contents, f)
+            sub_path = file_path[file_path.find(sub_path_prefix.get(X, '')):] if X in sub_path_prefix else file_path
+            entities = self.layout.parse_file_entities(sub_path)
+            subject, session = entities.get('subject'), entities.get('session')
+            sub_path = self._replace_placeholders(sub_path, subject, session)
+            json_contents[sub_path] = sub_path
+
+        output_file = self.json_dir / file_name
+        self._write_to_file(output_file, json_contents)
+
 
     def fetch_scan_type(self, Y, Z):
-        scan_type = ''
-        if Z.lower() in self.scan_type[Y]:
-            scan_type = self.scan_type[Y][Z.lower()]
-        elif '_' in Z:
-            first = Z.split('_')[0]
-            if first.lower() in self.scan_type[Y]:
-                scan_type = self.scan_type[Y][first.lower()]
-        if Y in self.scan_type[Y]:
-            scan_type = self.scan_type[Y][Y]
-        return scan_type
+        if Z.lower() in self.scan_type.get(Y, {}):
+            return self.scan_type[Y][Z.lower()]
+        if '_' in Z:
+            prefix = Z.split('_')[0]
+            if prefix.lower() in self.scan_type.get(Y, {}):
+                return self.scan_type[Y][prefix.lower()]
+        return self.scan_type.get(Y, {}).get(Y, '')
+
 
     def prepare_yaml_contents(self, file_name):
         _, _, Y, Z = self.extract_file_name_components(file_name)
@@ -111,89 +106,79 @@ class BIDStoNDAConfigGenerator:
             "scan_object": 'Live',
             "image_file_format": 'NIFTI',
             "image_modality": self.image_modality[Y],
-            "transformation_performed": 'Yes'
+            "transformation_performed": 'No'
         }
-        finalPath = '/'.join(self.path.split('/')[:-2]) + '/prepared_yamls'
-        Path(finalPath).mkdir(parents=True, exist_ok=True)
-        with open(f'{finalPath}/'+file_name, 'w') as f:
-            yaml.dump(yaml_contents, f)
+        output_file = self.yaml_dir / file_name
+        self._write_to_file(output_file, yaml_contents, file_format='yaml')
+
 
     def fetch_Z_value(self, files):
         Z = set()
         ignore_list = ['desc', 'subject', 'session', 'extension', 'suffix', 'datatype']
+        
         for file in files:
             entities = self.layout.parse_file_entities(file)
-            filtered_entities = {k: v for k,
-                                 v in entities.items() if k not in ignore_list}
+            filtered_entities = {k: v for k, v in entities.items() if k not in ignore_list}
+            
             for key, value in filtered_entities.items():
-                if key != 'space':
-                    z = key + '-' + value
-                else:
-                    z = value
-                if ({'suffix', 'datatype'} <= entities.keys() and entities['suffix'] != entities['datatype']) or \
-                        ('suffix' in entities and 'datatype' not in entities):
-                    if z:
-                        z = z + '_'
-                    z = z + entities['suffix']
+                z = f"{key}-{value}" if key != 'space' else value
+                if entities.get('suffix') and entities.get('suffix') != entities.get('datatype'):
+                    z = f"{z}_{entities['suffix']}" if z else entities['suffix']
                 if z:
                     Z.add(z) 
             if not Z and entities['suffix'] != entities['datatype']:
                 Z.add(entities['suffix'])
+                    
         return list(Z)
 
     def prepare_file_names(self, X, Y, Z):
-        file_names = defaultdict(set)
-        '''
-            file_names =  {
-                json: [],
-                yaml: []
-            }
-        '''
-
-        filename = f"{self.A}_{X}"
-        file_base = f"{filename}.{Y}."
-        for z in Z:
-            file_names['json'].add(file_base + z + '.json')
-            file_names['yaml'].add(file_base + z + '.yaml')
-        file_names['json'] = list(file_names['json'])
-        file_names['yaml'] = list(file_names['yaml'])
-        return file_names
-
-    def run(self):
-        X = []
-        Xi = self.layout.get(scope='raw')  # inputs
-        # Xd = self.layout.get(scope='derivatives')  # derivatives
-        Xs = self.layout.get(scope='sourcedata')  # sourcedata
-        if Xi:
-            X.append('inputs')
-        # if Xd:
-        #     X.append('derivatives')
-        if Xs:
-            X.append('sourcedata')
-
+        file_base = f"{self.A}_{X}.{Y}."
+        return {
+            'json': [f"{file_base}{z}.json" for z in Z],
+            'yaml': [f"{file_base}{z}.yaml" for z in Z]
+        }
+    
+    
+    def _replace_placeholders(self, path, subject, session):
+        if subject:
+            path = path.replace(subject, '{SUBJECT}')
+        if session:
+            path = path.replace(session, '{SESSION}')
+        return re.sub(r'-\d', '-{#}', path)
+    
+    def _write_to_file(self, output_file, contents, file_format='json'):
+        with open(output_file, 'w') as f:
+            if file_format == 'yaml':
+                yaml.dump(contents, f)
+            else:
+                json.dump(contents, f, indent=2)
+                
+                
+    def run(self): 
+        scopes = {
+            'raw': 'inputs',
+            'derivatives': 'derivatives',
+            'sourcedata': 'sourcedata'
+        }
+        X = [name for scope, name in scopes.items() if self.layout.get(scope=scope)]
         Y_types = self.layout.get_datatypes()
-
+        
         for x in X:
             for y in Y_types:
                 files = self.layout.get(
                     scope=x if x != 'inputs' else 'raw', datatype=y, return_type='file')
+                
                 Z = self.fetch_Z_value(files)
                 file_names = self.prepare_file_names(X=x, Y=y, Z=Z)
-                for file in file_names['json']:
-                    self.prepare_json_contents(file)
-                for file in file_names['yaml']:
-                    self.prepare_yaml_contents(file)
-        print()
-        print('Please check the following folders for the json and yaml files generated:')
-        print('JSON files: ' + '/'.join(self.path.split('/')[:-2]) + '/prepared_jsons')
-        print('YAML files: ' + '/'.join(self.path.split('/')[:-2]) + '/prepared_yamls')
-        print()
 
-# Instructions on how to use:
-# 1. Make sure you are in 'json_yaml_files' folder of the codebase
-# 2. Use the below command to run the script
-#   python3 prepare_files.py /Users/pbaba1/Downloads/NDA_Dataset/ds004733/
-# where '/Users/pbaba1/Downloads/NDA_Dataset/ds004733/' is the path where the BIDS dataset is located
+                for file_name in file_names['json']:
+                    self.prepare_json_contents(file_name, files)
+                for file_name in file_names['yaml']:
+                    self.prepare_yaml_contents(file_name)
+                    
+        print(f"\nJSON files: {self.json_dir}")
+        print(f"YAML files: {self.yaml_dir}\n")
 
-generator = BIDStoNDAConfigGenerator()
-generator.run()
+if __name__ == "__main__":
+    generator = BIDStoNDAConfigGenerator()
+    generator.run()

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -183,7 +183,11 @@ class BIDStoNDAConfigGenerator:
                     self.prepare_json_contents(file)
                 for file in file_names['yaml']:
                     self.prepare_yaml_contents(file)
-
+        print()
+        print('Please check the following folders for the json and yaml files generated:')
+        print('JSON files: ' + '/'.join(self.path.split('/')[:-2]) + '/prepared_jsons')
+        print('YAML files: ' + '/'.join(self.path.split('/')[:-2]) + '/prepared_yamls')
+        print()
 
 # Instructions on how to use:
 # 1. Make sure you are in 'json_yaml_files' folder of the codebase

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -1,4 +1,5 @@
 from bids import BIDSLayout
+import bids
 from collections import defaultdict
 import re
 import json
@@ -10,8 +11,12 @@ from pathlib import Path
 
 class BIDStoNDAConfigGenerator:
     def __init__(self):
-        # fetch the 
-        parser = argparse.ArgumentParser(description='Prepare JSON and YAML files for a single dataset path.')
+        # TODO:
+        # add below in the command line args
+        # -d: destination folder where the yaml and json files need to be saved
+        # -s: source directory where the BIDS dataset is located
+        bids.config.set_option('extension_initial_dot', True)
+        parser = argparse.ArgumentParser(description='Process a dataset path.')
         parser.add_argument('dataset_path', type=str, help='The path to the dataset directory')
         args = parser.parse_args()
         self.path = args.dataset_path
@@ -82,7 +87,6 @@ class BIDStoNDAConfigGenerator:
             else:
                 sub_index = file_path.find('sub-')
         finalPath = '/'.join(self.path.split('/')[:-2]) + '/prepared_jsons'
-        print(finalPath)
         Path(finalPath).mkdir(parents=True, exist_ok=True)
         with open(f'{finalPath}/'+file_name, 'w') as f:
             json.dump(json_contents, f)
@@ -132,13 +136,20 @@ class BIDStoNDAConfigGenerator:
                         z = z + '_'
                     z = z + entities['suffix']
                 if z:
-                    Z.add(z)
+                    Z.add(z) 
             if not Z and entities['suffix'] != entities['datatype']:
                 Z.add(entities['suffix'])
         return list(Z)
 
     def prepare_file_names(self, X, Y, Z):
         file_names = defaultdict(set)
+        '''
+            file_names =  {
+                json: [],
+                yaml: []
+            }
+        '''
+
         filename = f"{self.A}_{X}"
         file_base = f"{filename}.{Y}."
         for z in Z:

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -185,7 +185,11 @@ class BIDStoNDAConfigGenerator:
                     self.prepare_yaml_contents(file)
 
 
-# Example usage:
-# path = '/Users/pbaba1/Downloads/NDA_Dataset/ds004733/'
+# Instructions on how to use:
+# 1. Make sure you are in 'json_yaml_files' folder of the codebase
+# 2. Use the below command to run the script
+#   python3 prepare_files.py /Users/pbaba1/Downloads/NDA_Dataset/ds004733/
+# where '/Users/pbaba1/Downloads/NDA_Dataset/ds004733/' is the path where the BIDS dataset is located
+
 generator = BIDStoNDAConfigGenerator()
 generator.run()

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -1,0 +1,178 @@
+from bids import BIDSLayout
+from collections import defaultdict
+import re
+import json
+import sys
+import yaml
+from pathlib import Path
+
+
+class BIDStoNDAConfigGenerator:
+    def __init__(self):
+        self.path = sys.argv[1]
+        self.layout = BIDSLayout(self.path, derivatives=True)
+        self.A = 'image03'
+        self.pattern = r'^(?P<A>[^_]+)_(?P<X>[^.]+)\.(?P<Y>[^.]+)\.(?P<Z>[^.]+)\..+$'
+        # self.top_level_files = ['CHANGES',
+        #                         'README', 'dataset_description.json']
+        self.scan_type = {
+            'anat': {
+                'mprage': 'MR structural (MPRAGE)',
+                't1w': 'MR structural (T1)',
+                'pd': 'MR structural (PD)',
+                'fspgr': 'MR structural (FSPGR)',
+                'fsip': 'MR structural (FISP)',
+                't2w': 'MR structural (T2)',
+                'pd_t2': 'MR structural (PD, T2)',
+                'b0_map': 'MR structural (B0 map)',
+                'b1_map': 'MR structural (B1 map)',
+                'flash': 'MR structural (FLASH)',
+                'mp2rage': 'MR structural (MP2RAGE)',
+                'tse': 'MR structural (TSE)',
+                't1w_t2w': 'MR structural (T1, T2)',
+                'mpnrage': 'MR structural (MPnRAGE)'
+            },
+            'pet': {
+                'pet': 'PET'
+            }
+        }
+        self.image_modality = {
+            'pet': 'PET',
+            'anat': 'MRI',
+            'func': 'MRI',
+            'dwi': 'MRI',
+            'fmap': 'MRI'
+        }
+
+    def extract_file_name_components(self, file_name):
+        match = re.match(self.pattern, file_name)
+        if match:
+            A = match.group('A')
+            X = match.group('X')
+            Y = match.group('Y')
+            Z = match.group('Z')
+            return A, X, Y, Z
+        else:
+            return None
+
+    def prepare_json_contents(self, file_name):
+        # json_contents = {file: file for file in self.top_level_files}
+        json_contents = {}
+        _, X, Y, _ = self.extract_file_name_components(file_name)
+        files = self.layout.get(
+            scope=X if X != 'inputs' else 'raw', datatype=Y, return_type='file')
+        for file_path in files:
+            sub_index = file_path.find('derivatives')
+            if sub_index == -1:
+                sub_index = file_path.find('sub-')
+            if sub_index != -1:
+                sub_path = file_path[sub_index:]
+                entities = self.layout.parse_file_entities(sub_path)
+                subject = entities.get('subject')
+                session = entities.get('session')
+                if subject:
+                    sub_path = sub_path.replace(subject, '{SUBJECT}')
+                if session:
+                    sub_path = sub_path.replace(session, '{SESSION}')
+                sub_path = re.sub(r'-\d', '{#}', sub_path)
+                json_contents[sub_path] = sub_path
+        finalPath = '/'.join(self.path.split('/')[:-2]) + '/prepared_jsons'
+        print(finalPath)
+        Path(finalPath).mkdir(parents=True, exist_ok=True)
+        with open(f'{finalPath}/'+file_name, 'w') as f:
+            json.dump(json_contents, f)
+
+    def fetch_scan_type(self, Y, Z):
+        scan_type = ''
+        if Z.lower() in self.scan_type[Y]:
+            scan_type = self.scan_type[Y][Z.lower()]
+        elif '_' in Z:
+            first = Z.split('_')[0]
+            if first.lower() in self.scan_type[Y]:
+                scan_type = self.scan_type[Y][first.lower()]
+        if Y in self.scan_type[Y]:
+            scan_type = self.scan_type[Y][Y]
+        return scan_type
+
+    def prepare_yaml_contents(self, file_name):
+        _, _, Y, Z = self.extract_file_name_components(file_name)
+
+        yaml_contents = {
+            "scan_type": self.fetch_scan_type(Y, Z),
+            "scan_object": 'LIVE',
+            "image_file_format": 'NIFTI',
+            "image_modality": self.image_modality[Y],
+            "transformation_performed": 'Yes'
+        }
+        finalPath = '/'.join(self.path.split('/')[:-2]) + '/prepared_yamls'
+        Path(finalPath).mkdir(parents=True, exist_ok=True)
+        with open(f'{finalPath}/'+file_name, 'w') as f:
+            yaml.dump(yaml_contents, f)
+
+    def fetch_Z_value(self, files):
+        Z = set()
+        ignore_list = ['desc', 'subject', 'session',
+                       'extension', 'suffix', 'datatype']
+        for file in files:
+            entities = self.layout.parse_file_entities(file)
+            # print(entities)
+            filtered_entities = {k: v for k,
+                                 v in entities.items() if k not in ignore_list}
+            # print(filtered_entities)
+            for key, value in filtered_entities.items():
+                if key != 'space':
+                    z = key + '-' + value
+                else:
+                    z = value
+                if ({'suffix', 'datatype'} <= entities.keys() and entities['suffix'] != entities['datatype']) or \
+                        ('suffix' in entities and 'datatype' not in entities):
+                    if z:
+                        z = z + '_'
+                    z = z + entities['suffix']
+                if z:
+                    Z.add(z)
+            if not Z and entities['suffix'] != entities['datatype']:
+                Z.add(entities['suffix'])
+        return list(Z)
+
+    def prepare_file_names(self, X, Y, Z):
+        file_names = defaultdict(set)
+        filename = f"{self.A}_{X}"
+        file_base = f"{filename}.{Y}."
+        for z in Z:
+            file_names['json'].add(file_base + z + '.json')
+            file_names['yaml'].add(file_base + z + '.yaml')
+        file_names['json'] = list(file_names['json'])
+        file_names['yaml'] = list(file_names['yaml'])
+        return file_names
+
+    def run(self):
+        X = []
+        Xi = self.layout.get(scope='raw')  # inputs
+        # Xd = self.layout.get(scope='derivatives')  # derivatives
+        Xs = self.layout.get(scope='sourcedata')  # sourcedata
+        if Xi:
+            X.append('inputs')
+        # if Xd:
+        #     X.append('derivatives')
+        if Xs:
+            X.append('sourcedata')
+
+        Y_types = self.layout.get_datatypes()
+
+        for x in X:
+            for y in Y_types:
+                files = self.layout.get(
+                    scope=x if x != 'inputs' else 'raw', datatype=y, return_type='file')
+                Z = self.fetch_Z_value(files)
+                file_names = self.prepare_file_names(X=x, Y=y, Z=Z)
+                for file in file_names['json']:
+                    self.prepare_json_contents(file)
+                for file in file_names['yaml']:
+                    self.prepare_yaml_contents(file)
+
+
+# Example usage:
+# path = '/Users/pbaba1/Downloads/NDA_Dataset/ds004733/'
+generator = BIDStoNDAConfigGenerator()
+generator.run()

--- a/json_yaml_files/prepare_files.py
+++ b/json_yaml_files/prepare_files.py
@@ -11,7 +11,7 @@ from pathlib import Path
 class BIDStoNDAConfigGenerator:
     def __init__(self):
         # fetch the 
-        parser = argparse.ArgumentParser(description='Process a dataset path.')
+        parser = argparse.ArgumentParser(description='Prepare JSON and YAML files for a single dataset path.')
         parser.add_argument('dataset_path', type=str, help='The path to the dataset directory')
         args = parser.parse_args()
         self.path = args.dataset_path


### PR DESCRIPTION
We have branched the forked repo and provided the following script. It currently delivers all but derivatives for the test [ds004733](https://openneuro.org/datasets/ds004733) case.
Summary of the Script
The BIDStoNDAConfigGenerator is a Python script designed to automate the generation of JSON and YAML configuration files required for submitting neuroimaging data (specifically BIDS datasets) to the National Institute of Mental Health (NIMH) Data Archive (NDA). This script simplifies the process of converting BIDS-compliant datasets into NDA-compliant formats, focusing on PET and other neuroimaging modalities.
How the Script Works
1.	Initialization and Setup:
o	The script initializes by accepting the path to a BIDS dataset as a command-line argument.
o	It uses the BIDSLayout from the pybids library to organize and interact with the dataset.
o	The script defines mappings for scan types (e.g., anat, pet) and image modalities (e.g., MRI, PET).
2.	File Name Parsing:
o	The script uses a regular expression pattern to extract components (such as X, Y, Z) from the filenames within the BIDS dataset. These components are crucial for generating the correct NDA configuration files.
3.	Generating JSON Contents:
o	The prepare_json_contents method generates JSON files for each relevant scan in the dataset.
o	These JSON files contain placeholders ({SUBJECT}, {SESSION}) that will be filled in when the data is uploaded to the NDA.
4.	Fetching Scan Types:
o	The fetch_scan_type method identifies the appropriate scan type based on the Y and Z components extracted from the filename.
5.	Generating YAML Contents:
o	The prepare_yaml_contents method generates YAML files, which include metadata such as scan type, image modality, and file format.
6.	Determining Z Values:
o	The fetch_Z_value method extracts unique Z values from the dataset’s files, which are then used to generate the correct filenames for the JSON and YAML files.
7.	Running the Script:
o	The run method iterates through the dataset, generating and saving JSON and YAML files in specified directories.
o	The output directories are automatically created if they do not already exist.

Instructions for Use
1.	Prepare Your Environment:
o	Ensure you have the necessary dependencies installed, such as pybids.
2.	Running the Script:
o	Place yourself in the directory where the script is located and execute the following command:
bash
Copy code
python3 prepare_files.py /path/to/bids/dataset
o	Replace /path/to/bids/dataset with the actual path to your BIDS dataset.
3.	Output:
o	The script generates JSON and YAML files in directories named prepared_jsons and prepared_yamls, respectively.
o	These directories are created in the parent directory of the BIDS dataset.
Next Steps
This script forms the basis of a tool aimed at automating the process of submitting datasets from OpenNeuro and OpenNeuroPET into the NIMH Data Archive. Future enhancements could include:
•	Customizable Output Directories: Allowing users to specify output directories for the generated files via command-line arguments.
•	Support for Additional Data Types: Extending support to other neuroimaging modalities beyond PET and MRI.
•	Integration with NDA Submission Tools: Automating the actual submission process to the NDA, including manifest file creation.
Additional Notes
This tool is part of a broader project aimed at streamlining the data submission process for neuroimaging studies, particularly for datasets in BIDS format. By automating the creation of necessary configuration files, this tool reduces the manual effort required and ensures compliance with NDA requirements.